### PR TITLE
fix: library refers to `window` instead of the `global` object in Nod…

### DIFF
--- a/build/webpack.prod.js
+++ b/build/webpack.prod.js
@@ -14,5 +14,6 @@ module.exports = merge(common, {
         library: 'Cowrie',
         libraryTarget: 'umd',
         libraryExport: 'default',
+        globalObject: 'this',
     },
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cowrie/cowrie",
-    "version": "1.0.0-beta",
+    "version": "1.0.0-beta.2",
     "license": "MIT",
     "description": "Cowrie is a JavaScript utility that allows you to add, subtract, multiply, divide, sort & partition monetary values",
     "homepage": "https://github.com/cowrie-io/cowrie#readme",


### PR DESCRIPTION
…e.js

1. Added the globalObject property and set the value to 'this' in webpack.prod.js
2. Updated the package.json version to '1.0.0-beta.2'